### PR TITLE
Fix compile after changes from commit e0ff7967441fa0401c190e1d250ac3e57a122f5

### DIFF
--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.cpp
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.cpp
@@ -36,3 +36,8 @@ void FQtCreatorSourceCodeAccessModule::ShutdownModule()
 	// unbind provider from editor
 	IModularFeatures::Get().UnregisterModularFeature(TEXT("SourceCodeAccessor"), &QtCreatorSourceCodeAccessor);
 }
+
+FQtCreatorSourceCodeAccessor& FQtCreatorSourceCodeAccessModule::GetAccessor()
+{
+	return QtCreatorSourceCodeAccessor;
+}

--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.h
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.h
@@ -29,6 +29,7 @@ public:
 	/** IModuleInterface implementation */
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
+	FQtCreatorSourceCodeAccessor& GetAccessor();
 
 private:
 	FQtCreatorSourceCodeAccessor QtCreatorSourceCodeAccessor;

--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp
@@ -134,6 +134,11 @@ bool FQtCreatorSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& Absolu
   return true;
 }
 
+bool FQtCreatorSourceCodeAccessor::AddSourceFiles(const TArray<FString>& AbsoluteSourcePaths, const TArray<FString>& AvailableModules)
+{
+	return false;
+}
+
 bool FQtCreatorSourceCodeAccessor::SaveAllOpenDocuments() const
 {
   return false;

--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.h
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.h
@@ -34,6 +34,7 @@ public:
 	virtual bool OpenSolution() override;
 	virtual bool OpenFileAtLine(const FString& FullPath, int32 LineNumber, int32 ColumnNumber = 0) override;
 	virtual bool OpenSourceFiles(const TArray<FString>& AbsoluteSourcePaths) override;
+	virtual bool AddSourceFiles(const TArray<FString>& AbsoluteSourcePaths, const TArray<FString>& AvailableModules) override;
 	virtual bool SaveAllOpenDocuments() const override;
 	virtual void Tick(const float DeltaTime) override;
 };


### PR DESCRIPTION
virtual class method...
virtual bool AddSourceFiles(const TArray<FString>& AbsoluteSourcePaths, const TArray<FString>& AvailableModules) override;

 ...was added to the base virtual class and caused a failed compile due to the virtual classes not matching up.