### PR TITLE
Mention compilation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This project is under the MIT license. By submitting a patch to the project you 
 
 Clone this to your UnrealEngine directory at `Engine/Plugins/Developer`.
 
+Compile the plugin. May require a full recompile of the editor.
+
 Enable this as your code view editor.
 
 Add to Engine/Config/Linux/LinuxEngine.ini


### PR DESCRIPTION
As it is, the plugin won't work if dropped into a precompiled UE4 environment. Gotta either distribute binaries, or tell people to compile it (preferably with an included makefile).