### PR TITLE
reorder headers in order to fix build errors on clang-3.9.1/ue-14.5.0

### DIFF
--- a/QtCreatorSourceCodeAccess.uplugin
+++ b/QtCreatorSourceCodeAccess.uplugin
@@ -5,7 +5,7 @@
 	"VersionName" : "1.0",
 	"CreatedBy" : "K. S. Ernest 'iFire' Lee",
 	"CreatedByURL" : "https://github.com/fire/QtCreatorSourceCodeAccess.git",
-	"EngineVersion" : "4.10.0",
+	"EngineVersion" : "4.16.0",
 	"Description" : "Allows access to source code with Qt Creator.",
 	"Category": "Programming",
 	"EnabledByDefault" : true,

--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.cpp
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.cpp
@@ -20,9 +20,9 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include "QtCreatorSourceCodeAccessModule.h"
 #include "QtCreatorSourceCodeAccessPrivatePCH.h"
 #include "Runtime/Core/Public/Features/IModularFeatures.h"
-#include "QtCreatorSourceCodeAccessModule.h"
 
 IMPLEMENT_MODULE( FQtCreatorSourceCodeAccessModule, QtCreatorSourceCodeAccess );
 

--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp
@@ -23,8 +23,8 @@
 // Add a class to handle the Solution file locally
 // instead of relying on FDesktopPlatformModule.
 
-#include "QtCreatorSourceCodeAccessPrivatePCH.h"
 #include "QtCreatorSourceCodeAccessor.h"
+#include "QtCreatorSourceCodeAccessPrivatePCH.h"
 #include "DesktopPlatformModule.h"
 
 #define LOCTEXT_NAMESPACE "QtCreatorSourceCodeAccessor"

--- a/Source/QtCreatorSourceCodeAccess/QtCreatorSourceCodeAccess.Build.cs
+++ b/Source/QtCreatorSourceCodeAccess/QtCreatorSourceCodeAccess.Build.cs
@@ -24,7 +24,7 @@ namespace UnrealBuildTool.Rules
 {
 	public class QtCreatorSourceCodeAccess : ModuleRules
 	{
-                 public QtCreatorSourceCodeAccess(TargetInfo Target)
+                 public QtCreatorSourceCodeAccess(ReadOnlyTargetRules Target) : base(Target)
 		 {
 		 	PrivateDependencyModuleNames.AddRange(
                                 new string[]


### PR DESCRIPTION
I get a bunch of errors like this:

```
/opt/UnrealEngine/Engine/Plugins/Developer/QtCreatorSourceCodeAccess/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp(1): error: Expected QtCreatorSourceCodeAccessor.h to be first header included.
/opt/UnrealEngine/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessModule.cpp(1): error: Expected SensibleEditorSourceCodeAccessModule.h to be first header included.
/opt/UnrealEngine/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp(1): error: Expected SensibleEditorSourceCodeAccessor.h to be first header included.
Build canceled.
```

And if I reorder the headers as the error says it builds just fine.