### PR TITLE
Fix headers include sequence

### DIFF
--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.cpp
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessModule.cpp
@@ -20,9 +20,9 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include "QtCreatorSourceCodeAccessModule.h"
 #include "QtCreatorSourceCodeAccessPrivatePCH.h"
 #include "Runtime/Core/Public/Features/IModularFeatures.h"
-#include "QtCreatorSourceCodeAccessModule.h"
 
 IMPLEMENT_MODULE( FQtCreatorSourceCodeAccessModule, QtCreatorSourceCodeAccess );
 

--- a/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp
+++ b/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp
@@ -23,8 +23,8 @@
 // Add a class to handle the Solution file locally
 // instead of relying on FDesktopPlatformModule.
 
-#include "QtCreatorSourceCodeAccessPrivatePCH.h"
 #include "QtCreatorSourceCodeAccessor.h"
+#include "QtCreatorSourceCodeAccessPrivatePCH.h"
 #include "DesktopPlatformModule.h"
 
 #define LOCTEXT_NAMESPACE "QtCreatorSourceCodeAccessor"
@@ -45,7 +45,7 @@ FName FQtCreatorSourceCodeAccessor::GetFName() const
         return FName("QtCreatorSourceCodeAccessor");
 }
 
-FText FQtCreatorSourceCodeAccessor::GetNameText() const 
+FText FQtCreatorSourceCodeAccessor::GetNameText() const
 {
         return LOCTEXT("QtCreatorDisplayName", "Qt Creator");
 }
@@ -115,9 +115,9 @@ bool FQtCreatorSourceCodeAccessor::OpenFileAtLine(const FString& FullPath, int32
         return false;
 }
 
-bool FQtCreatorSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& AbsoluteSourcePaths) 
+bool FQtCreatorSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& AbsoluteSourcePaths)
 {
-        for ( const FString& SourcePath : AbsoluteSourcePaths ) 
+        for ( const FString& SourcePath : AbsoluteSourcePaths )
         {
                 FString Editor = FString(TEXT("/usr/bin/qtcreator"));
                 FString Args = FString(TEXT("-client "));
@@ -153,7 +153,7 @@ bool FQtCreatorSourceCodeAccessor::SaveAllOpenDocuments() const
         return false;
 }
 
-void FQtCreatorSourceCodeAccessor::Tick(const float DeltaTime) 
+void FQtCreatorSourceCodeAccessor::Tick(const float DeltaTime)
 {
 
 }


### PR DESCRIPTION
The Unreal Engine compiler (4.15.1) refused to compile module because
it expected QtCreatorSourceCodeAccessModule.h to be first header
included.