### PR TITLE
make the plugin build and work with UE 4.16.x

### DIFF
--- a/QtCreatorSourceCodeAccess.uplugin
+++ b/QtCreatorSourceCodeAccess.uplugin
@@ -5,7 +5,7 @@
 	"VersionName" : "1.0",
 	"CreatedBy" : "K. S. Ernest 'iFire' Lee",
 	"CreatedByURL" : "https://github.com/fire/QtCreatorSourceCodeAccess.git",
-	"EngineVersion" : "4.10.0",
+	"EngineVersion" : "4.16.0",
 	"Description" : "Allows access to source code with Qt Creator.",
 	"Category": "Programming",
 	"EnabledByDefault" : true,

--- a/Source/QtCreatorSourceCodeAccess/QtCreatorSourceCodeAccess.Build.cs
+++ b/Source/QtCreatorSourceCodeAccess/QtCreatorSourceCodeAccess.Build.cs
@@ -24,7 +24,7 @@ namespace UnrealBuildTool.Rules
 {
 	public class QtCreatorSourceCodeAccess : ModuleRules
 	{
-                 public QtCreatorSourceCodeAccess(TargetInfo Target)
+                 public QtCreatorSourceCodeAccess(ReadOnlyTargetRules Target) : base(Target)
 		 {
 		 	PrivateDependencyModuleNames.AddRange(
                                 new string[]


### PR DESCRIPTION
The plugin fails to build on UE 4.16.x. Furthermore, on UE 4.16.x it keeps asking to enable/disable the plugin at each startup. This pull request resolves those issues.

Please note that this pull request requires pull request #21 