### PR TITLE
Update for 4.24.1

### DIFF
--- a/QtCreatorSourceCodeAccess.uplugin
+++ b/QtCreatorSourceCodeAccess.uplugin
@@ -1,24 +1,27 @@
 {
-	"FileVersion": 3,
-	"Version": 1,
-	"VersionName": "1.0",
-	"FriendlyName": "Qt Creator Source Code Access",
-	"Description": "Allows access to source code with Qt Creator.",
-	"Category": "Programming",
-	"CreatedBy": "K. S. Ernest 'iFire' Lee",
-	"CreatedByURL": "https://github.com/fire/QtCreatorSourceCodeAccess.git",
-	"DocsURL": "",
-	"MarketplaceURL": "",
-	"SupportURL": "",
-	"EngineVersion": "4.22.0",
-	"CanContainContent": false,
-	"Installed": true,
-	"Modules": [
+	"FileVersion" : 3,
+	"Version" : 1,
+	"VersionName" : "1.0",
+	"FriendlyName" : "Qt Creator Integration",
+	"Description" : "Allows access to source code in Qt Creator.",
+	"Category" : "Programming",
+	"CreatedBy" : "K. S. Ernest 'iFire' Lee",
+	"CreatedByURL" : "https://github.com/fire/QtCreatorSourceCodeAccess.git",
+	"DocsURL" : "",
+	"MarketplaceURL" : "",
+	"SupportURL" : "",
+	"EnabledByDefault" : false,
+	"CanContainContent" : false,
+	"IsBetaVersion" : false,
+	"Installed" : true,
+	"Modules" :
+	[
 		{
-			"Name": "QtCreatorSourceCodeAccess",
-			"Type": "Developer",
-			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [
+			"Name" : "QtCreatorSourceCodeAccess",
+			"Type" : "UncookedOnly",
+			"LoadingPhase" : "Default",
+			"WhitelistPlatforms" :
+			[
 				"Linux"
 			]
 		}


### PR DESCRIPTION
`Developer` was depretaded and need to be replaced with `UncookedOnly`. I updated `.uplugin` according to [CLion plugin](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Plugins/Developer/CLionSourceCodeAccess/CLionSourceCodeAccess.uplugin).